### PR TITLE
Eliminate performance issues stemming from repeated re-allocation of result object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+RJDBC.Rproj
+.Rbuildignore

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,4 @@
 exportClasses(JDBCDriver, JDBCConnection, JDBCResult)
-import(methods, DBI, rJava)
+import(methods, DBI, rJava, data.table)
 exportMethods(dbClearResult,dbColumnInfo,dbCommit,dbConnect,dbDataType,dbDisconnect,dbExistsTable,dbGetException,dbGetInfo,dbGetQuery,dbListConnections,dbListFields,dbListResults,dbListTables,dbReadTable,dbRemoveTable,dbRollback,dbSendQuery,dbSendUpdate,dbUnloadDriver,dbWriteTable,dbGetTables,dbGetFields,fetch)
 export(JDBC)

--- a/R/class.R
+++ b/R/class.R
@@ -306,9 +306,10 @@ setMethod("fetch", signature(res="JDBCResult", n="numeric"), def=function(res, n
     .verify.JDBC.result(rp, "cannot instantiate JDBCResultPull hepler class")
   }
   if (n < 0L) { ## infinite pull
-    print(length(l))
+    
     stride <- 32768L  ## start fairly small to support tiny queries and increase later
     while ((nrec <- .jcall(rp, "I", "fetch", stride, block)) > 0L) {
+      print(length(l[[1]]))
       for (i in seq.int(cols))
         l[[i]] <- c(l[[i]], if (cts[i] == 1L) .jcall(rp, "[D", "getDoubles", i) else .jcall(rp, "[Ljava/lang/String;", "getStrings", i))
       if (nrec < stride) break

--- a/R/class.R
+++ b/R/class.R
@@ -289,16 +289,23 @@ setMethod("fetch", signature(res="JDBCResult", n="numeric"), def=function(res, n
   block <- as.integer(block)
   if (length(block) != 1L) stop("invalid block size")
   if (cols < 1L) return(NULL)
-  l <- list()
+  
+  
+  l_template <- list() ## Original allocation of l
+  
+  l_container <- list()
+  length(l_container) <- 1024 ## Allocate a length for the number of blocks it might take to pull back
+  l_container_used_elements <- 0L
+  
   cts <- rep(0L, cols)
   for (i in 1:cols) {
     ct <- .jcall(res@md, "I", "getColumnType", i)
     if (ct == -5 | ct ==-6 | (ct >= 2 & ct <= 8)) {
-      l[[i]] <- numeric()
+      l_template[[i]] <- numeric()
       cts[i] <- 1L
     } else
-      l[[i]] <- character()
-    names(l)[i] <- .jcall(res@md, "S", "getColumnName", i)
+      l_template[[i]] <- character()
+    names(l_template)[i] <- .jcall(res@md, "S", "getColumnName", i)
   }
   rp <- res@pull
   if (is.jnull(rp)) {
@@ -306,22 +313,28 @@ setMethod("fetch", signature(res="JDBCResult", n="numeric"), def=function(res, n
     .verify.JDBC.result(rp, "cannot instantiate JDBCResultPull hepler class")
   }
   if (n < 0L) { ## infinite pull
-    print(length(l))
     stride <- 32768L  ## start fairly small to support tiny queries and increase later
     while ((nrec <- .jcall(rp, "I", "fetch", stride, block)) > 0L) {
+      
+      l_container_used_elements <- l_container_used_elements + 1L
+      print(l_container_used_elements)
+      l <- l_template
+      
       for (i in seq.int(cols))
-        l[[i]] <- c(l[[i]], if (cts[i] == 1L) .jcall(rp, "[D", "getDoubles", i) else .jcall(rp, "[Ljava/lang/String;", "getStrings", i))
+        l[[i]] <- if (cts[i] == 1L) .jcall(rp, "[D", "getDoubles", i) else .jcall(rp, "[Ljava/lang/String;", "getStrings", i)
+      l_container[[l_container_used_elements]] <- l
       if (nrec < stride) break
       stride <- 524288L # 512k
     }
   } else {
     nrec <- .jcall(rp, "I", "fetch", as.integer(n), block)
     for (i in seq.int(cols)) l[[i]] <- if (cts[i] == 1L) .jcall(rp, "[D", "getDoubles", i) else .jcall(rp, "[Ljava/lang/String;", "getStrings", i)
+    l_container[[l_container_used_elements]] <- l
   }
-  # as.data.frame is expensive - create it on the fly from the list
-  attr(l, "row.names") <- c(NA_integer_, length(l[[1]]))
-  class(l) <- "data.frame"
-  l
+  ## as.data.frame is expensive - create it on the fly from the list
+  # attr(l, "row.names") <- c(NA_integer_, length(l[[1]]))
+  # class(l) <- "data.frame"
+  l_container[[1:l_container_used_elements]]
 })
 
 setMethod("dbClearResult", "JDBCResult",

--- a/R/class.R
+++ b/R/class.R
@@ -313,14 +313,14 @@ setMethod("fetch", signature(res="JDBCResult", n="numeric"), def=function(res, n
     .verify.JDBC.result(rp, "cannot instantiate JDBCResultPull hepler class")
   }
   if (n < 0L) { ## infinite pull
-
+    
     stride <- 32768L  ## start fairly small to support tiny queries and increase later
     while ((nrec <- .jcall(rp, "I", "fetch", stride, block)) > 0L) {
       
       l_container_used_elements <- l_container_used_elements + 1L
       print(l_container_used_elements)
       l <- l_template
-
+      
       for (i in seq.int(cols))
         l[[i]] <- if (cts[i] == 1L) .jcall(rp, "[D", "getDoubles", i) else .jcall(rp, "[Ljava/lang/String;", "getStrings", i)
       l_container[[l_container_used_elements]] <- l
@@ -337,7 +337,7 @@ setMethod("fetch", signature(res="JDBCResult", n="numeric"), def=function(res, n
   # class(l) <- "data.frame"
   # l_container[[1:l_container_used_elements]]
   l_container
-})
+}, valueClass = "list")
 
 setMethod("dbClearResult", "JDBCResult",
           def = function(res, ...) { .jcall(res@jr, "V", "close"); .jcall(res@stat, "V", "close"); TRUE },

--- a/R/class.R
+++ b/R/class.R
@@ -285,7 +285,6 @@ setMethod("dbRollback", "JDBCConnection", def=function(conn, ...) {.jcall(conn@j
 setClass("JDBCResult", representation("DBIResult", jr="jobjRef", md="jobjRef", stat="jobjRef", pull="jobjRef"))
 
 setMethod("fetch", signature(res="JDBCResult", n="numeric"), def=function(res, n, block=2048L, ...) {
-  print("Matt Github Branch")
   cols <- .jcall(res@md, "I", "getColumnCount")
   block <- as.integer(block)
   if (length(block) != 1L) stop("invalid block size")
@@ -307,6 +306,7 @@ setMethod("fetch", signature(res="JDBCResult", n="numeric"), def=function(res, n
     .verify.JDBC.result(rp, "cannot instantiate JDBCResultPull hepler class")
   }
   if (n < 0L) { ## infinite pull
+    print(length(l))
     stride <- 32768L  ## start fairly small to support tiny queries and increase later
     while ((nrec <- .jcall(rp, "I", "fetch", stride, block)) > 0L) {
       for (i in seq.int(cols))

--- a/R/class.R
+++ b/R/class.R
@@ -316,19 +316,20 @@ setMethod("fetch", signature(res="JDBCResult", n="numeric"), def=function(res, n
     while ((nrec <- .jcall(rp, "I", "fetch", stride, block)) > 0L) {
       
       l_container_used_elements <- l_container_used_elements + 1L
-      l <- l_template
+      l_container[[l_container_used_elements]] <- l_template
       
       for (i in seq.int(cols)){
-        l[[i]] <- if (cts[i] == 1L) .jcall(rp, "[D", "getDoubles", i) else .jcall(rp, "[Ljava/lang/String;", "getStrings", i)
+        l_container[[l_container_used_elements]][[i]] <- if (cts[i] == 1L) .jcall(rp, "[D", "getDoubles", i) else .jcall(rp, "[Ljava/lang/String;", "getStrings", i)
       }
-      l_container[[l_container_used_elements]] <- l
+      
       if (nrec < stride) break
       stride <- 524288L # 512k
     }
   } else {
     nrec <- .jcall(rp, "I", "fetch", as.integer(n), block)
-    for (i in seq.int(cols)) l[[i]] <- if (cts[i] == 1L) .jcall(rp, "[D", "getDoubles", i) else .jcall(rp, "[Ljava/lang/String;", "getStrings", i)
-    l_container[[l_container_used_elements]] <- l
+    for (i in seq.int(cols)) {
+      l_container[[l_container_used_elements]][[i]] <- if (cts[i] == 1L) .jcall(rp, "[D", "getDoubles", i) else .jcall(rp, "[Ljava/lang/String;", "getStrings", i)
+    }
   }
 
   data.table::rbindlist(l_container[1:l_container_used_elements])

--- a/R/class.R
+++ b/R/class.R
@@ -346,3 +346,4 @@ setMethod("dbColumnInfo", "JDBCResult", def = function(res, ...) {
 },
           valueClass = "data.frame")
 
+## MS

--- a/R/class.R
+++ b/R/class.R
@@ -285,6 +285,7 @@ setMethod("dbRollback", "JDBCConnection", def=function(conn, ...) {.jcall(conn@j
 setClass("JDBCResult", representation("DBIResult", jr="jobjRef", md="jobjRef", stat="jobjRef", pull="jobjRef"))
 
 setMethod("fetch", signature(res="JDBCResult", n="numeric"), def=function(res, n, block=2048L, ...) {
+  print("Matt Github Branch")
   cols <- .jcall(res@md, "I", "getColumnCount")
   block <- as.integer(block)
   if (length(block) != 1L) stop("invalid block size")
@@ -346,3 +347,4 @@ setMethod("dbColumnInfo", "JDBCResult", def = function(res, ...) {
 },
           valueClass = "data.frame")
 
+## MS

--- a/R/class.R
+++ b/R/class.R
@@ -335,7 +335,8 @@ setMethod("fetch", signature(res="JDBCResult", n="numeric"), def=function(res, n
   ## as.data.frame is expensive - create it on the fly from the list
   # attr(l, "row.names") <- c(NA_integer_, length(l[[1]]))
   # class(l) <- "data.frame"
-  l_container[[1:l_container_used_elements]]
+  # l_container[[1:l_container_used_elements]]
+  l_container
 })
 
 setMethod("dbClearResult", "JDBCResult",


### PR DESCRIPTION
When pulling a large-ish query, I noticed that a surprising amount of the processing time to create the R data frame from the result set was spent on garbage collection.

I looked a little bit deeper, and noticed that the list `l` within the `fetch` method was concatenated with each new block and re-assigned, requiring the entire object to be reallocated multiple times. For small queries this doesn't have a major impact on performance, but on queries with 1 million+ rows, the processing time grows in a non-linear manner.

I re-wrote a nested list to avoid the need to re-assign previously processed results for each block, and then used `rbindlist()` from the `data.table` package to concatenate them and return an object with classes "data.table" and "data.frame".

I used data.table because of the faster speed of `rbindlist()` compared to base R data frame methods *(and because returning a data.table saves me a step)*. However, I completely understand if you want to avoid adding a dependency and use base-r `rbind()` or other base concatenation methods and just eliminate the re-assignment within the loop.

### Benchmarking

The screenshot below compares profiling results of the current CRAN version (top) and the version in this PR for a query that returns a 1.5 GB result set (7,582,102 rows of 2 character columns and 15 numeric columns).

My bench marking method is as follows, I'm only profiling the `y <- fetch(x, -1L)` statement to avoid data base execution time from being included in the comparison.

```r
Query <- "SELECT 
character_column_1,
character_column_2,
numeric_column_1,
numeric_column_2,
numeric_column_3,
numeric_column_4,
numeric_column_5,
numeric_column_6,
numeric_column_7,
numeric_column_8,
numeric_column_9,
numeric_column_10,
numeric_column_11,
numeric_column_12,
numeric_column_13,
numeric_column_14,
numeric_column_15
FROM table
WHERE character_column_1 LIKE criteria
AND numeric_column_1 BETWEEN 100 AND 200"

x <- dbSendQuery(HIVE, statement = Query)
gc()
y <- fetch(x, -1L)
```
The CRAN version takes about twice as long to return *(130 seconds vs 63 seconds)*, and I'm pretty sure that the performance improvement will increase with result size.

Thoughts?

This branch can be installed for testing with:

```r
install_github("msummersgill/RJDBC",ref = "direct-assign", force = TRUE)
```

![image](https://user-images.githubusercontent.com/19575728/29938385-336f7194-8e4e-11e7-9c02-9513153fb056.png)
